### PR TITLE
Update to new version of nalgebra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.4"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4541eb06dce09c0241ebbaab7102f0a01a0c8994afed2e5d0d66775016e25ac2"
+checksum = "3c4b5f057b303842cf3262c27e465f4c303572e7f6b0648f60e16248ac3397f4"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -730,13 +730,13 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1622,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
 dependencies = [
  "approx",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ rust-version = "1.67.0"
 
 [dependencies]
 faer = { version = "0.19.0", default-features = false }
-nalgebra = { version = "0.32", default-features = false, optional = true }
+nalgebra = { version = "0.33", default-features = false, optional = true }
 ndarray = { version = "0.15", default-features = false, optional = true }
 num-complex = { version = "0.4.5", default-features = false }
 polars = { version = "0.40", features = ["lazy"], optional = true }
 
 [dev-dependencies]
-nalgebra = { version = "0.32" }
+nalgebra = { version = "0.33" }
 
 [features]
 default = []


### PR DESCRIPTION
I'm using the new version of nalgebra and would love to use faer with it:) 

This works locally, so I can't imagine there'll be any issues.