### PR TITLE
Update to ndarray 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,14 +811,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -1361,6 +1363,21 @@ dependencies = [
  "stacker",
  "sysinfo",
  "version_check",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdd8420072e66d54a407b3316991fe946ce3ab1083a7f575b2463866624704d"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.67.0"
 [dependencies]
 faer = { version = "0.19.0", default-features = false }
 nalgebra = { version = "0.32", default-features = false, optional = true }
-ndarray = { version = "0.15", default-features = false, optional = true }
+ndarray = { version = "0.16", default-features = false, optional = true }
 num-complex = { version = "0.4.5", default-features = false }
 polars = { version = "0.40", features = ["lazy"], optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ const _: () = {
     use faer::complex_native::*;
     use faer::prelude::*;
     use faer::SimpleEntity;
-    use ndarray::{ArrayView, ArrayViewMut, IntoDimension, Ix2, ShapeBuilder};
+    use ndarray::{ArrayView, ArrayViewMut, Ix2, ShapeBuilder};
     use num_complex::{Complex32, Complex64};
 
     impl<'a, T: SimpleEntity> IntoFaer for ArrayView<'a, T, Ix2> {
@@ -422,8 +422,7 @@ const _: () = {
             unsafe {
                 ArrayView::<'_, T, Ix2>::from_shape_ptr(
                     (nrows, ncols)
-                        .into_shape()
-                        .strides((row_stride, col_stride).into_dimension()),
+                        .strides((row_stride, col_stride)),
                     ptr,
                 )
             }
@@ -443,8 +442,7 @@ const _: () = {
             unsafe {
                 ArrayViewMut::<'_, T, Ix2>::from_shape_ptr(
                     (nrows, ncols)
-                        .into_shape()
-                        .strides((row_stride, col_stride).into_dimension()),
+                        .strides((row_stride, col_stride)),
                     ptr,
                 )
             }
@@ -490,8 +488,7 @@ const _: () = {
             unsafe {
                 ArrayView::<'_, Complex32, Ix2>::from_shape_ptr(
                     (nrows, ncols)
-                        .into_shape()
-                        .strides((row_stride, col_stride).into_dimension()),
+                        .strides((row_stride, col_stride)),
                     ptr,
                 )
             }
@@ -511,8 +508,7 @@ const _: () = {
             unsafe {
                 ArrayViewMut::<'_, Complex32, Ix2>::from_shape_ptr(
                     (nrows, ncols)
-                        .into_shape()
-                        .strides((row_stride, col_stride).into_dimension()),
+                        .strides((row_stride, col_stride)),
                     ptr,
                 )
             }
@@ -558,8 +554,7 @@ const _: () = {
             unsafe {
                 ArrayView::<'_, Complex64, Ix2>::from_shape_ptr(
                     (nrows, ncols)
-                        .into_shape()
-                        .strides((row_stride, col_stride).into_dimension()),
+                        .strides((row_stride, col_stride)),
                     ptr,
                 )
             }
@@ -579,8 +574,7 @@ const _: () = {
             unsafe {
                 ArrayViewMut::<'_, Complex64, Ix2>::from_shape_ptr(
                     (nrows, ncols)
-                        .into_shape()
-                        .strides((row_stride, col_stride).into_dimension()),
+                        .strides((row_stride, col_stride)),
                     ptr,
                 )
             }
@@ -593,7 +587,7 @@ const _: () = {
 const _: () =
     {
         use nalgebra::{Dim, Dyn, MatrixView, MatrixViewMut, ViewStorage, ViewStorageMut};
-        use ndarray::{ArrayView, ArrayViewMut, IntoDimension, Ix2, ShapeBuilder};
+        use ndarray::{ArrayView, ArrayViewMut, Ix2, ShapeBuilder};
         use num_complex::Complex;
 
         impl<'a, T> IntoNalgebra for ArrayView<'a, T, Ix2> {
@@ -670,8 +664,7 @@ const _: () =
                 unsafe {
                     ArrayView::<'_, T, Ix2>::from_shape_ptr(
                         (nrows, ncols)
-                            .into_shape()
-                            .strides((row_stride, col_stride).into_dimension()),
+                            .strides((row_stride, col_stride)),
                         ptr,
                     )
                 }
@@ -692,8 +685,7 @@ const _: () =
                 unsafe {
                     ArrayViewMut::<'_, T, Ix2>::from_shape_ptr(
                         (nrows, ncols)
-                            .into_shape()
-                            .strides((row_stride, col_stride).into_dimension()),
+                            .strides((row_stride, col_stride)),
                         ptr,
                     )
                 }


### PR DESCRIPTION
Only minor changes needed.
Apologies for the ShapeBuilder stuff, the new code is how it was intended to be used (which works with both 0.15 and 0.16, even if there were breaking changes in the helper trait ShapeBuilder.)