### PR TITLE
chore: Update faer version in faer-ext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["math", "matrix", "linear-algebra"]
 rust-version = "1.67.0"
 
 [dependencies]
-faer = { version = "0.20.0", default-features = false }
+faer = { version = "0.21.4", default-features = false }
 nalgebra = { version = "0.33", default-features = false, optional = true }
 ndarray = { version = "0.16", default-features = false, optional = true }
 num-complex = { version = "0.4.5", default-features = false }


### PR DESCRIPTION
This is necessary in order to make `faer-ext` compatible with the latest version (`21.4`) of `faer`.
This is duplicated in #4, but would be nice to get merged quickly without making a decision on `numpy` support.